### PR TITLE
Admin Review Management: add status & reported list filters

### DIFF
--- a/src/core/entities/interfaces/admin.entity.interface.ts
+++ b/src/core/entities/interfaces/admin.entity.interface.ts
@@ -151,6 +151,28 @@ export interface IReportTransactionData {
 export interface IAdminReviewStats {
   totalReviews: number;
   activeReviews: number;
+  inactiveReviews: number;
   reportedReviews: number;
   averageRating: number;
+  distribution: IReviewDistribution[];
+}
+
+export interface IReviewDistribution {
+  rating: number;
+  count: number;
+  percentage: number;
+}
+
+export interface ILowestRatedProvider {
+  providerId: string;
+  providerName: string;
+  providerAvatar: string;
+  avgRating: number;
+  totalReviews: number;
+}
+
+export interface IRatingTrendPoint {
+  date: string;
+  avgRating: number;
+  count: number;
 }

--- a/src/core/entities/interfaces/report.entity.interface.ts
+++ b/src/core/entities/interfaces/report.entity.interface.ts
@@ -2,7 +2,7 @@ import { IEntity } from "@core/entities/base/interfaces/base-entity.entity.inter
 import { IPagination } from "@core/entities/interfaces/booking.entity.interface";
 import { ComplaintReason, ReportStatus } from "@core/enum/report.enum";
 
-export type ReportedType = 'customer' | 'provider';
+export type ReportedType = 'customer' | 'provider' | 'review';
 
 export interface IReport extends IEntity {
     reportedId: string;

--- a/src/core/entities/interfaces/user.entity.interface.ts
+++ b/src/core/entities/interfaces/user.entity.interface.ts
@@ -177,6 +177,8 @@ export interface IReviewFilters {
   sortBy?: SortByRatingType;
   search?: string;
   searchBy?: SearchByReviewType;
+  status?: boolean | 'all';
+  isReported?: boolean | 'all';
   page?: number;
 }
 

--- a/src/core/enum/ratings.enum.ts
+++ b/src/core/enum/ratings.enum.ts
@@ -7,6 +7,7 @@ export enum RatingsSortBy {
 
 export enum RatingSearchBy {
     ReviewId = 'review id',
+    Customer = 'customer',
     Provider = 'provider',
     Content = 'content',
 }

--- a/src/core/guards/admin-role.guard.ts
+++ b/src/core/guards/admin-role.guard.ts
@@ -1,0 +1,29 @@
+import { Request } from 'express';
+
+import { ErrorCodes, ErrorMessage } from '@core/enum/error.enum';
+import { IPayload } from '@core/misc/payload.interface';
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+
+@Injectable()
+export class AdminRoleGuard implements CanActivate {
+    canActivate(context: ExecutionContext): boolean {
+        const request: Request = context.switchToHttp().getRequest();
+        const user = request.user as IPayload;
+
+        if (!user || !user.sub || !user.type) {
+            throw new UnauthorizedException({
+                code: ErrorCodes.UNAUTHORIZED_ACCESS,
+                message: ErrorMessage.UNAUTHORIZED_ACCESS
+            });
+        }
+
+        if (user.type !== 'admin') {
+            throw new ForbiddenException({
+                code: ErrorCodes.FORBIDDEN,
+                message: 'Admin access required.'
+            });
+        }
+
+        return true;
+    }
+}

--- a/src/core/repositories/implementations/bookings.repository.ts
+++ b/src/core/repositories/implementations/bookings.repository.ts
@@ -7,7 +7,7 @@ import { IBookingPerformanceData, IComparisonChartData, IComparisonOverviewData,
 import { BookingDocument, SlotDocument } from '@core/schema/bookings.schema';
 import { BaseRepository } from '@core/repositories/base/implementations/base.repository';
 import { IBookingRepository } from '@core/repositories/interfaces/bookings-repo.interface';
-import { IAdminReviewStats, IBookingReportData, IReportCustomerMatrix, IReportDownloadBookingData, IReportProviderMatrix } from '@core/entities/interfaces/admin.entity.interface';
+import { IAdminReviewStats, IReviewDistribution, ILowestRatedProvider, IRatingTrendPoint, IBookingReportData, IReportCustomerMatrix, IReportDownloadBookingData, IReportProviderMatrix } from '@core/entities/interfaces/admin.entity.interface';
 import { SlotStatusEnum } from '@core/enum/slot.enum';
 import { BookingStatus, CancelStatus, PaymentStatus } from '@core/enum/bookings.enum';
 import { UpdateQuery } from 'mongoose';
@@ -2406,6 +2406,14 @@ export class BookingRepository extends BaseRepository<BookingDocument> implement
             match['review.rating'] = { $gte: Number(filter.minRating) };
         }
 
+        if (filter.status !== undefined && filter.status !== 'all') {
+            match['review.isActive'] = filter.status === true;
+        }
+
+        if (filter.isReported !== undefined && filter.isReported !== 'all') {
+            match['review.isReported'] = filter.isReported === true;
+        }
+
         const pipeline: PipelineStage[] = [];
 
         pipeline.push(
@@ -2438,8 +2446,8 @@ export class BookingRepository extends BaseRepository<BookingDocument> implement
                         $expr: { $regexMatch: { input: { $toString: '$_id' }, regex: searchRegex } }
                     }
                 });
-                // } else if (filter.searchBy === 'customer') {
-                //     pipeline.push({ $match: { 'customer.username': searchRegex } });
+            } else if (filter.searchBy === 'customer') {
+                pipeline.push({ $match: { 'customer.username': searchRegex } });
             } else if (filter.searchBy === 'provider') {
                 pipeline.push({ $match: { 'provider.username': searchRegex } });
             } else if (filter.searchBy === 'content') {
@@ -2508,40 +2516,144 @@ export class BookingRepository extends BaseRepository<BookingDocument> implement
     }
 
     async getAdminReviewStats(): Promise<IAdminReviewStats> {
-        const result = await this._bookingModel.aggregate([
+        interface ReviewStatsFacet {
+            stats: { totalReviews: number; activeReviews: number; inactiveReviews: number; reportedReviews: number; averageRating: number }[];
+            distribution: { _id: number; count: number }[];
+        }
+
+        const [facetResult] = await this._bookingModel.aggregate<ReviewStatsFacet>([
             { $match: { review: { $exists: true, $ne: null } } },
             {
-                $group: {
-                    _id: null,
-                    totalReviews: { $sum: 1 },
-                    activeReviews: {
-                        $sum: { $cond: [{ $eq: ["$review.isActive", true] }, 1, 0] }
-                    },
-                    reportedReviews: {
-                        $sum: { $cond: [{ $eq: ["$review.isReported", true] }, 1, 0] }
-                    },
-                    averageRating: { $avg: "$review.rating" }
+                $facet: {
+                    stats: [
+                        {
+                            $group: {
+                                _id: null,
+                                totalReviews: { $sum: 1 },
+                                activeReviews: {
+                                    $sum: { $cond: [{ $eq: ["$review.isActive", true] }, 1, 0] }
+                                },
+                                inactiveReviews: {
+                                    $sum: { $cond: [{ $eq: ["$review.isActive", false] }, 1, 0] }
+                                },
+                                reportedReviews: {
+                                    $sum: { $cond: [{ $eq: ["$review.isReported", true] }, 1, 0] }
+                                },
+                                averageRating: {
+                                    $avg: {
+                                        $cond: [{ $eq: ["$review.isActive", true] }, "$review.rating", null]
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    distribution: [
+                        { $group: { _id: "$review.rating", count: { $sum: 1 } } }
+                    ]
                 }
             }
         ]);
 
-        return result[0] ? {
-            totalReviews: result[0].totalReviews,
-            activeReviews: result[0].activeReviews,
-            reportedReviews: result[0].reportedReviews,
-            averageRating: Math.round((result[0].averageRating || 0) * 10) / 10
+        const stats = facetResult?.stats?.[0];
+        const distributionMap = new Map<number, number>(
+            (facetResult?.distribution ?? []).map((item) => [item._id, item.count])
+        );
+        const distributionTotal = Array.from(distributionMap.values()).reduce((sum, count) => sum + count, 0);
+        const distribution: IReviewDistribution[] = [5, 4, 3, 2, 1].map((rating) => {
+            const count = distributionMap.get(rating) ?? 0;
+            return {
+                rating,
+                count,
+                percentage: distributionTotal > 0 ? Math.round((count / distributionTotal) * 100) : 0
+            };
+        });
+
+        return stats ? {
+            totalReviews: stats.totalReviews,
+            activeReviews: stats.activeReviews,
+            inactiveReviews: stats.inactiveReviews,
+            reportedReviews: stats.reportedReviews,
+            averageRating: Math.round((stats.averageRating || 0) * 10) / 10,
+            distribution
         } : {
             totalReviews: 0,
             activeReviews: 0,
+            inactiveReviews: 0,
             reportedReviews: 0,
-            averageRating: 0
+            averageRating: 0,
+            distribution
         };
+    }
+
+    async getLowestRatedProviders(limit: number = 5): Promise<ILowestRatedProvider[]> {
+        return await this._bookingModel.aggregate([
+            { $match: { review: { $exists: true, $ne: null }, 'review.isActive': true } },
+            {
+                $group: {
+                    _id: "$providerId",
+                    avgRating: { $avg: "$review.rating" },
+                    totalReviews: { $sum: 1 }
+                }
+            },
+            { $match: { totalReviews: { $gte: 5 } } },
+            { $lookup: { from: 'providers', localField: '_id', foreignField: '_id', as: 'provider' } },
+            { $unwind: '$provider' },
+            {
+                $project: {
+                    _id: 0,
+                    providerId: { $toString: '$_id' },
+                    providerName: '$provider.username',
+                    providerAvatar: { $ifNull: ['$provider.avatar', ''] },
+                    avgRating: { $round: ['$avgRating', 1] },
+                    totalReviews: 1
+                }
+            },
+            { $sort: { avgRating: 1, totalReviews: 1 } },
+            { $limit: limit }
+        ]);
+    }
+
+    async getRatingTrend(days: number = 30): Promise<IRatingTrendPoint[]> {
+        const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+        return await this._bookingModel.aggregate([
+            {
+                $match: {
+                    review: { $exists: true, $ne: null },
+                    'review.isActive': true,
+                    'review.writtenAt': { $gte: since }
+                }
+            },
+            {
+                $group: {
+                    _id: { $dateToString: { format: '%Y-%m-%d', date: '$review.writtenAt' } },
+                    avgRating: { $avg: '$review.rating' },
+                    count: { $sum: 1 }
+                }
+            },
+            {
+                $project: {
+                    _id: 0,
+                    date: '$_id',
+                    avgRating: { $round: ['$avgRating', 1] },
+                    count: 1
+                }
+            },
+            { $sort: { date: 1 } }
+        ]);
     }
 
     async updateReviewStatus(reviewId: string, status: boolean): Promise<boolean> {
         const result = await this._bookingModel.updateOne(
             { _id: this._toObjectId(reviewId) },
             { $set: { 'review.isActive': status } }
+        );
+        return result.matchedCount > 0;
+    }
+
+    async markReviewReported(reviewId: string): Promise<boolean> {
+        const result = await this._bookingModel.updateOne(
+            { _id: this._toObjectId(reviewId), review: { $exists: true, $ne: null } },
+            { $set: { 'review.isReported': true } }
         );
         return result.modifiedCount > 0;
     }

--- a/src/core/repositories/interfaces/bookings-repo.interface.ts
+++ b/src/core/repositories/interfaces/bookings-repo.interface.ts
@@ -3,7 +3,7 @@ import { IBookingStats, IRatingDistribution, IRevenueMonthlyGrowthRateData, IRev
 import { IBookingPerformanceData, IComparisonChartData, IComparisonOverviewData, IOnTimeArrivalChartData, IProviderRevenueOverview, IResponseTimeChartData, IReviewFilters, ITopProviders, ITotalReviewAndAvgRating, PaginatedReviewResponse } from '@core/entities/interfaces/user.entity.interface';
 import { IBaseRepository } from '@core/repositories/base/interfaces/base-repo.interface';
 import { BookingDocument, SlotDocument } from '@core/schema/bookings.schema';
-import { IAdminReviewStats, IBookingReportData, IReportCustomerMatrix, IReportDownloadBookingData, IReportProviderMatrix } from '@core/entities/interfaces/admin.entity.interface';
+import { IAdminReviewStats, ILowestRatedProvider, IRatingTrendPoint, IBookingReportData, IReportCustomerMatrix, IReportDownloadBookingData, IReportProviderMatrix } from '@core/entities/interfaces/admin.entity.interface';
 import { BookingStatus, CancelStatus, PaymentStatus } from '@core/enum/bookings.enum';
 
 export interface IBookingRepository extends IBaseRepository<BookingDocument> {
@@ -70,7 +70,10 @@ export interface IBookingRepository extends IBaseRepository<BookingDocument> {
     getNextAvailableSlot(providerId: string): Promise<ISlot & { date: Date }>;
     getAdminReviews(filter: IReviewFilters): Promise<PaginatedReviewResponse>;
     getAdminReviewStats(): Promise<IAdminReviewStats>;
+    getLowestRatedProviders(limit: number): Promise<ILowestRatedProvider[]>;
+    getRatingTrend(days: number): Promise<IRatingTrendPoint[]>;
     updateReviewStatus(reviewId: string, status: boolean): Promise<boolean>;
+    markReviewReported(reviewId: string): Promise<boolean>;
     rescheduleBooking(bookingId: string, newExpectedArrivalTime:Date, newSlot: IBookedSlot): Promise<BookingDocument | null>;
 }
 

--- a/src/core/schema/report.schema.ts
+++ b/src/core/schema/report.schema.ts
@@ -19,7 +19,7 @@ export class ReportDocument extends Document {
 
     @Prop({
         type: String,
-        enum: ['customer', 'provider'],
+        enum: ['customer', 'provider', 'review'],
         required: true
     })
     type: ReportedType;

--- a/src/modules/providers/services/implementations/provider.service.ts
+++ b/src/modules/providers/services/implementations/provider.service.ts
@@ -84,10 +84,6 @@ export class ProviderServices implements IProviderServices {
     this.logger = this.loggerFactory.createLogger(ProviderServices.name);
   }
 
-  private _customerSearchRadiusMeters(): number {
-    return GeoEnum.DEFAULT_CUSTOMER_SEARCH_RADIUS_KM * GeoEnum.KM_TO_METERS;
-  }
-
   async getProviders(filters: FilterDto): Promise<IResponse<IProviderCardWithPagination>> {
     const { page = 1, limit = 10, availability, date, categoryId, providerIds: providerIdsParam, ...filter } = filters;
 
@@ -516,12 +512,13 @@ export class ProviderServices implements IProviderServices {
     const reviews = pageDocs.flatMap(b =>
       b.review && b.review.isActive
         ? [{
-            ...b.review,
-            name: customerMap[b.customerId.toString()]?.username,
-            avatar: customerMap[b.customerId.toString()]?.avatar ?? '',
-            email: customerMap[b.customerId.toString()]?.email,
-            writtenAt: new Date(b.review.writtenAt ?? b.createdAt)
-          }]
+          ...b.review,
+          reviewId: String((b as { _id: unknown })._id ?? ''),
+          name: customerMap[b.customerId.toString()]?.username,
+          avatar: customerMap[b.customerId.toString()]?.avatar ?? '',
+          email: customerMap[b.customerId.toString()]?.email,
+          writtenAt: new Date(b.review.writtenAt ?? b.createdAt)
+        }]
         : []
     );
 
@@ -544,19 +541,6 @@ export class ProviderServices implements IProviderServices {
       message: 'Reviews fetched successfully.',
       data: displayReviews
     }
-  }
-
-  private _encodeReviewCursor(writtenAt: Date, bookingId: string): string {
-    return `${new Date(writtenAt).toISOString()}|${bookingId}`;
-  }
-
-  private _parseReviewCursor(cursor: string): { writtenAt: Date; bookingId: string } | null {
-    const separatorIndex = cursor.lastIndexOf('|');
-    if (separatorIndex <= 0) return null;
-    const writtenAt = new Date(cursor.slice(0, separatorIndex));
-    const bookingId = cursor.slice(separatorIndex + 1);
-    if (!bookingId || isNaN(writtenAt.getTime())) return null;
-    return { writtenAt, bookingId };
   }
 
   async updatePassword(providerId: string, currentPassword: string, newPassword: string): Promise<IResponse> {
@@ -926,5 +910,23 @@ export class ProviderServices implements IProviderServices {
       this._timeUtility.timeToMinutes(a.from) - this._timeUtility.timeToMinutes(b.from)
     );
   }
+
+  private _customerSearchRadiusMeters(): number {
+    return GeoEnum.DEFAULT_CUSTOMER_SEARCH_RADIUS_KM * GeoEnum.KM_TO_METERS;
+  }
+
+  private _encodeReviewCursor(writtenAt: Date, bookingId: string): string {
+    return `${new Date(writtenAt).toISOString()}|${bookingId}`;
+  }
+
+  private _parseReviewCursor(cursor: string): { writtenAt: Date; bookingId: string } | null {
+    const separatorIndex = cursor.lastIndexOf('|');
+    if (separatorIndex <= 0) return null;
+    const writtenAt = new Date(cursor.slice(0, separatorIndex));
+    const bookingId = cursor.slice(separatorIndex + 1);
+    if (!bookingId || isNaN(writtenAt.getTime())) return null;
+    return { writtenAt, bookingId };
+  }
+
 }
 

--- a/src/modules/reports/providers/repository.providers.ts
+++ b/src/modules/reports/providers/repository.providers.ts
@@ -1,8 +1,10 @@
-import { CUSTOMER_MODEL_NAME, PROVIDER_MODEL_NAME, REPORT_MODEL_NAME } from "@core/constants/model.constant";
-import { CUSTOMER_REPOSITORY_INTERFACE_NAME, PROVIDER_REPOSITORY_INTERFACE_NAME, REPORT_REPOSITORY_NAME } from "@core/constants/repository.constant";
+import { BOOKINGS_MODEL_NAME, CUSTOMER_MODEL_NAME, PROVIDER_MODEL_NAME, REPORT_MODEL_NAME } from "@core/constants/model.constant";
+import { BOOKING_REPOSITORY_NAME, CUSTOMER_REPOSITORY_INTERFACE_NAME, PROVIDER_REPOSITORY_INTERFACE_NAME, REPORT_REPOSITORY_NAME } from "@core/constants/repository.constant";
+import { BookingRepository } from "@core/repositories/implementations/bookings.repository";
 import { CustomerRepository } from "@core/repositories/implementations/customer.repository";
 import { ProviderRepository } from "@core/repositories/implementations/provider.repository";
 import { ReportRepository } from "@core/repositories/implementations/report.repository";
+import { BookingDocument } from "@core/schema/bookings.schema";
 import { CustomerDocument } from "@core/schema/customer.schema";
 import { ProviderDocument } from "@core/schema/provider.schema";
 import { ReportDocument } from "@core/schema/report.schema";
@@ -16,6 +18,12 @@ export const reportRepositoryProvider: Provider[] = [
         useFactory: (reportModel: Model<ReportDocument>) =>
             new ReportRepository(reportModel),
         inject: [getModelToken(REPORT_MODEL_NAME)]
+    },
+    {
+        provide: BOOKING_REPOSITORY_NAME,
+        useFactory: (bookingModel: Model<BookingDocument>) =>
+            new BookingRepository(bookingModel),
+        inject: [getModelToken(BOOKINGS_MODEL_NAME)]
     },
     {
         provide: CUSTOMER_REPOSITORY_INTERFACE_NAME,

--- a/src/modules/reports/services/implementation/report.service.ts
+++ b/src/modules/reports/services/implementation/report.service.ts
@@ -1,11 +1,12 @@
 import { REPORT_MAPPER } from "@core/constants/mappers.constant";
-import { CUSTOMER_REPOSITORY_INTERFACE_NAME, PROVIDER_REPOSITORY_INTERFACE_NAME, REPORT_REPOSITORY_NAME } from "@core/constants/repository.constant";
+import { BOOKING_REPOSITORY_NAME, CUSTOMER_REPOSITORY_INTERFACE_NAME, PROVIDER_REPOSITORY_INTERFACE_NAME, REPORT_REPOSITORY_NAME } from "@core/constants/repository.constant";
 import { UPLOAD_UTILITY_NAME } from "@core/constants/utility.constant";
 import { IReportMapper } from "@core/dto-mapper/interface/report.mapper.interface";
-import { IReportDetail, IReportFilter, IReportOverViewMatrix, IReportWithPagination, ReportedType } from "@core/entities/interfaces/report.entity.interface";
+import { IReport, IReportDetail, IReportFilter, IReportOverViewMatrix, IReportWithPagination, ReportedType } from "@core/entities/interfaces/report.entity.interface";
 import { ErrorCodes, ErrorMessage } from "@core/enum/error.enum";
 import { ReportStatus } from "@core/enum/report.enum";
 import { IResponse } from "@core/misc/response.util";
+import { IBookingRepository } from "@core/repositories/interfaces/bookings-repo.interface";
 import { ICustomerRepository } from "@core/repositories/interfaces/customer-repo.interface";
 import { IProviderRepository } from "@core/repositories/interfaces/provider-repo.interface";
 import { IReportRepository } from "@core/repositories/interfaces/report-repo.interface";
@@ -20,6 +21,8 @@ export class ReportService implements IReportService {
     constructor(
         @Inject(REPORT_REPOSITORY_NAME)
         private readonly _reportRepository: IReportRepository,
+        @Inject(BOOKING_REPOSITORY_NAME)
+        private readonly _bookingRepository: IBookingRepository,
         @Inject(CUSTOMER_REPOSITORY_INTERFACE_NAME)
         private readonly _customerRepository: ICustomerRepository,
         @Inject(PROVIDER_REPOSITORY_INTERFACE_NAME)
@@ -37,6 +40,10 @@ export class ReportService implements IReportService {
             type,
             status: ReportStatus.PENDING,
         }));
+
+        if (type === 'review' && reported) {
+            await this._bookingRepository.markReviewReported(report.targetId);
+        }
 
         return {
             success: !!reported,
@@ -74,6 +81,16 @@ export class ReportService implements IReportService {
         });
 
         let report = this._reportMapper.toEntity(reportDoc);
+
+        if (report.status === ReportStatus.PENDING) {
+            const updatedReportDoc = await this._reportRepository.updateReportStatus(report.id, ReportStatus.IN_PROGRESS)
+            report = updatedReportDoc ? this._reportMapper.toEntity(updatedReportDoc) : report;
+        }
+
+        if (report.type === 'review') {
+            return this._buildReviewReportDetail(report);
+        }
+
         let customerId: string;
         let providerId: string;
 
@@ -95,11 +112,6 @@ export class ReportService implements IReportService {
             this._providerRepository.findById(providerId),
         ]);
 
-        if (report.status === ReportStatus.PENDING) {
-            const updatedReportDoc = await this._reportRepository.updateReportStatus(report.id, ReportStatus.IN_PROGRESS)
-            report = updatedReportDoc ? this._reportMapper.toEntity(updatedReportDoc) : report;
-        }
-
         if (!customerDoc || !providerDoc) throw new NotFoundException({
             code: ErrorCodes.DATABASE_OPERATION_FAILED,
             message: ErrorMessage.DOCUMENT_NOT_FOUND
@@ -113,32 +125,81 @@ export class ReportService implements IReportService {
         const targetId = isCustomerReported ? providerId : customerId;
         const targetDoc = isCustomerReported ? providerDoc : customerDoc;
 
-        const reportDetails: IReportDetail = {
-            id: report.id,
-            reportedBy: {
-                reportedId,
-                name: reportedDoc.username,
-                email: reportedDoc.email,
-                avatar: this._uploadsUtility.getSignedImageUrl(reportedDoc.avatar, 60 * 10)
-            },
-            target: {
-                targetId,
-                name: targetDoc.username,
-                email: targetDoc.email,
-                avatar: this._uploadsUtility.getSignedImageUrl(targetDoc.avatar, 60 * 10)
-            },
-            reason: report.reason,
-            status: report.status,
-            type: report.type,
-            description: report.description,
-            createdAt: report.createdAt as Date,
-            updatedAt: report.updatedAt as Date,
-        };
+        return {
+            success: true,
+            message: 'Report details fetched successfully',
+            data: {
+                id: report.id,
+                reportedBy: {
+                    reportedId,
+                    name: reportedDoc.username,
+                    email: reportedDoc.email,
+                    avatar: this._uploadsUtility.getSignedImageUrl(reportedDoc.avatar, 60 * 10)
+                },
+                target: {
+                    targetId,
+                    name: targetDoc.username,
+                    email: targetDoc.email,
+                    avatar: this._uploadsUtility.getSignedImageUrl(targetDoc.avatar, 60 * 10)
+                },
+                reason: report.reason,
+                status: report.status,
+                type: report.type,
+                description: report.description,
+                createdAt: report.createdAt as Date,
+                updatedAt: report.updatedAt as Date,
+            }
+        }
+    }
+
+    private async _buildReviewReportDetail(report: IReport): Promise<IResponse<IReportDetail>> {
+        const [reviewerCustomer, reviewerProvider] = await Promise.all([
+            this._customerRepository.findById(report.reportedId),
+            this._providerRepository.findById(report.reportedId),
+        ]);
+
+        const reviewerDoc = reviewerCustomer ?? reviewerProvider;
+        if (!reviewerDoc) throw new NotFoundException({
+            code: ErrorCodes.DATABASE_OPERATION_FAILED,
+            message: ErrorMessage.DOCUMENT_NOT_FOUND
+        });
+
+        const booking = await this._bookingRepository.findById(report.targetId);
+        if (!booking) throw new NotFoundException({
+            code: ErrorCodes.DATABASE_OPERATION_FAILED,
+            message: ErrorMessage.DOCUMENT_NOT_FOUND
+        });
+
+        const providerDoc = await this._providerRepository.findById(booking.providerId.toString());
+        if (!providerDoc) throw new NotFoundException({
+            code: ErrorCodes.DATABASE_OPERATION_FAILED,
+            message: ErrorMessage.DOCUMENT_NOT_FOUND
+        });
 
         return {
             success: true,
             message: 'Report details fetched successfully',
-            data: reportDetails
+            data: {
+                id: report.id,
+                reportedBy: {
+                    reportedId: report.reportedId,
+                    name: reviewerDoc.username,
+                    email: reviewerDoc.email,
+                    avatar: this._uploadsUtility.getSignedImageUrl(reviewerDoc.avatar, 60 * 10)
+                },
+                target: {
+                    targetId: report.targetId,
+                    name: providerDoc.username,
+                    email: providerDoc.email,
+                    avatar: this._uploadsUtility.getSignedImageUrl(providerDoc.avatar, 60 * 10)
+                },
+                reason: report.reason,
+                status: report.status,
+                type: report.type,
+                description: report.description,
+                createdAt: report.createdAt as Date,
+                updatedAt: report.updatedAt as Date,
+            }
         }
     }
 

--- a/src/modules/users/controllers/approvals.controller.ts
+++ b/src/modules/users/controllers/approvals.controller.ts
@@ -3,13 +3,15 @@ import {
     IApprovalOverviewData, IApprovalTableDetails
 } from '@core/entities/interfaces/user.entity.interface';
 import { ErrorMessage } from '@core/enum/error.enum';
+import { AdminRoleGuard } from '@core/guards/admin-role.guard';
 import { CustomLogger } from '@core/logger/implementation/custom-logger';
 import { IResponse } from '@core/misc/response.util';
 import {
     IAdminApprovalService
 } from '@modules/users/services/interfaces/admin-approval-service.interface';
-import { Controller, Get, Inject, InternalServerErrorException, Logger, Req } from '@nestjs/common';
+import { Controller, Get, Inject, InternalServerErrorException, Logger, Req, UseGuards } from '@nestjs/common';
 
+@UseGuards(AdminRoleGuard)
 @Controller('admin/approvals')
 export class AdminApprovalsController {
     private readonly logger = new CustomLogger(AdminApprovalsController.name);

--- a/src/modules/users/controllers/bookings.controller.ts
+++ b/src/modules/users/controllers/bookings.controller.ts
@@ -1,14 +1,16 @@
 import { ADMIN_BOOKINGS_SERVICE_NAME } from '@core/constants/service.constant';
 import { IAdminBookingDetails, IBookingStats, IPaginatedBookingsResponse } from '@core/entities/interfaces/booking.entity.interface';
 import { ErrorMessage } from '@core/enum/error.enum';
+import { AdminRoleGuard } from '@core/guards/admin-role.guard';
 import { CustomLogger } from '@core/logger/implementation/custom-logger';
 import { IResponse } from '@core/misc/response.util';
 import { isValidIdPipe } from '@core/pipes/is-valid-id.pipe';
 import { BookingReportDownloadDto, AdminBookingFilterDto } from '@modules/users/dtos/admin-user.dto';
 import { IAdminBookingService } from '@modules/users/services/interfaces/admin-bookings-service.interface';
-import { Body, Controller, Get, Inject, InternalServerErrorException, Param, Post, Query, Res } from '@nestjs/common';
+import { Body, Controller, Get, Inject, InternalServerErrorException, Param, Post, Query, Res, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 
+@UseGuards(AdminRoleGuard)
 @Controller('admin/bookings')
 export class AdminBookingController {
     private readonly logger = new CustomLogger(AdminBookingController.name);

--- a/src/modules/users/controllers/dashboard.controller.ts
+++ b/src/modules/users/controllers/dashboard.controller.ts
@@ -5,14 +5,16 @@ import {
 } from '@core/entities/interfaces/admin.entity.interface';
 import { ITopProviders } from '@core/entities/interfaces/user.entity.interface';
 import { ErrorMessage } from '@core/enum/error.enum';
+import { AdminRoleGuard } from '@core/guards/admin-role.guard';
 import { ICustomLogger } from '@core/logger/interface/custom-logger.interface';
 import { ILoggerFactory, LOGGER_FACTORY } from '@core/logger/interface/logger-factory.interface';
 import { IResponse } from '@core/misc/response.util';
 import {
     IAdminDashboardOverviewService
 } from '@modules/users/services/interfaces/admin-dashboard-overview-service.interface';
-import { Controller, Get, Inject, InternalServerErrorException } from '@nestjs/common';
+import { Controller, Get, Inject, InternalServerErrorException, UseGuards } from '@nestjs/common';
 
+@UseGuards(AdminRoleGuard)
 @Controller('admin/dashboard')
 export class AdminDashboardController {
     private readonly logger: ICustomLogger;

--- a/src/modules/users/controllers/reviews.controller.ts
+++ b/src/modules/users/controllers/reviews.controller.ts
@@ -1,12 +1,14 @@
 import { ADMIN_REVIEWS_SERVICE_NAME } from '@core/constants/service.constant';
 import { PaginatedReviewResponse } from '@core/entities/interfaces/user.entity.interface';
 import { ErrorMessage } from '@core/enum/error.enum';
+import { AdminRoleGuard } from '@core/guards/admin-role.guard';
 import { CustomLogger } from '@core/logger/implementation/custom-logger';
 import { IResponse } from '@core/misc/response.util';
-import { FilterWithPaginationDto, UpdateReviewStatus } from '@modules/users/dtos/admin-user.dto';
+import { FilterWithPaginationDto, LowestRatedQueryDto, RatingTrendQueryDto, UpdateReviewStatus } from '@modules/users/dtos/admin-user.dto';
 import { IAdminReviewService } from '@modules/users/services/interfaces/admin-reviews-service.interface';
-import { Body, Controller, Get, Inject, Patch, Query } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Patch, Query, UseGuards } from '@nestjs/common';
 
+@UseGuards(AdminRoleGuard)
 @Controller('admin/reviews')
 export class ReviewController {
     private readonly logger = new CustomLogger(ReviewController.name);
@@ -24,6 +26,16 @@ export class ReviewController {
     @Get('stats')
     async getReviewStats() {
         return await this._reviewService.reviewStats();
+    }
+
+    @Get('lowest_rated')
+    async getLowestRatedProviders(@Query() query: LowestRatedQueryDto) {
+        return await this._reviewService.lowestRatedProviders(query.limit);
+    }
+
+    @Get('rating_trend')
+    async getRatingTrend(@Query() query: RatingTrendQueryDto) {
+        return await this._reviewService.ratingTrend(query.days);
     }
 
     @Patch('status')

--- a/src/modules/users/controllers/settings.controller.ts
+++ b/src/modules/users/controllers/settings.controller.ts
@@ -1,10 +1,12 @@
 import { ADMIN_SETTINGS_SERVICE_NAME } from "@core/constants/service.constant";
 import { IAdminSettings } from "@core/entities/interfaces/admin-settings.entity.interface";
+import { AdminRoleGuard } from "@core/guards/admin-role.guard";
 import { IResponse } from "@core/misc/response.util";
 import { SettingsDto } from "@modules/users/dtos/admin-user.dto";
 import { IAdminSettingService } from "@modules/users/services/interfaces/settings-service.interface";
-import { Body, Controller, Get, Inject, Patch } from "@nestjs/common";
+import { Body, Controller, Get, Inject, Patch, UseGuards } from "@nestjs/common";
 
+@UseGuards(AdminRoleGuard)
 @Controller('admin/settings')
 export class AdminSettingsController {
     constructor(

--- a/src/modules/users/controllers/transaction.controller.ts
+++ b/src/modules/users/controllers/transaction.controller.ts
@@ -1,6 +1,7 @@
 import { ADMIN_TRANSACTION_SERVICE_NAME } from "@core/constants/service.constant";
 import { User } from "@core/decorators/extract-user.decorator";
 import { IAdminTransactionDataWithPagination, ITransactionStats } from "@core/entities/interfaces/wallet-ledger.entity.interface";
+import { AdminRoleGuard } from "@core/guards/admin-role.guard";
 import { ICustomLogger } from "@core/logger/interface/custom-logger.interface";
 import { ILoggerFactory, LOGGER_FACTORY } from "@core/logger/interface/logger-factory.interface";
 import { IPayload } from "@core/misc/payload.interface";
@@ -8,9 +9,10 @@ import { IResponse } from "@core/misc/response.util";
 import { TransactionReportDownloadDto } from "@modules/users/dtos/admin-user.dto";
 import { IAdminTransactionService } from "@modules/users/services/interfaces/admin-transaction-service.interface";
 import { ProviderWalletFilterDto } from "@modules/wallet/dto/wallet.dto";
-import { Body, Controller, Get, Inject, Post, Query, Res } from "@nestjs/common";
+import { Body, Controller, Get, Inject, Post, Query, Res, UseGuards } from "@nestjs/common";
 import { Response } from "express";
 
+@UseGuards(AdminRoleGuard)
 @Controller('admin/transactions')
 export class AdminTransactionController {
     private readonly logger: ICustomLogger;

--- a/src/modules/users/controllers/user.controller.ts
+++ b/src/modules/users/controllers/user.controller.ts
@@ -1,13 +1,15 @@
 import { ADMIN_USER_MANAGEMENT_SERVICE_NAME } from '@core/constants/service.constant';
 import { IUserDataWithPagination } from '@core/entities/interfaces/admin.entity.interface';
 import { ErrorMessage } from '@core/enum/error.enum';
+import { AdminRoleGuard } from '@core/guards/admin-role.guard';
 import { ICustomLogger } from '@core/logger/interface/custom-logger.interface';
 import { ILoggerFactory, LOGGER_FACTORY } from '@core/logger/interface/logger-factory.interface';
 import { GetUsersWithFilterDto, RemoveUserDto, StatusUpdateDto, UserReportDownloadDto } from '@modules/users/dtos/admin-user.dto';
 import { IAdminUserManagementService } from '@modules/users/services/interfaces/admin-user-service.interface';
-import { BadRequestException, Body, Controller, Get, Inject, InternalServerErrorException, Patch, Post, Query, Res } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Inject, InternalServerErrorException, Patch, Post, Query, Res, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 
+@UseGuards(AdminRoleGuard)
 @Controller('admin/users')
 export class AdminUserController {
   private readonly logger: ICustomLogger;

--- a/src/modules/users/dtos/admin-user.dto.ts
+++ b/src/modules/users/dtos/admin-user.dto.ts
@@ -113,6 +113,42 @@ export class FilterWithPaginationDto extends PageDto {
     @IsOptional()
     @IsEnum(RatingSearchBy)
     searchBy?: RatingSearchBy;
+
+    @IsOptional()
+    @Transform(({ value }) => {
+        if (value === 'true') return true;
+        if (value === 'false') return false;
+        if (value === 'all') return 'all';
+        return value;
+    })
+    @IsIn([true, false, 'all'])
+    status?: FilterStatusType;
+
+    @IsOptional()
+    @Transform(({ value }) => {
+        if (value === 'true') return true;
+        if (value === 'false') return false;
+        if (value === 'all') return 'all';
+        return value;
+    })
+    @IsIn([true, false, 'all'])
+    isReported?: FilterStatusType;
+}
+
+export class LowestRatedQueryDto {
+    @IsOptional()
+    @Transform(({ value }) => Number(value) || 5)
+    @IsNumber()
+    @Min(1)
+    limit?: number;
+}
+
+export class RatingTrendQueryDto {
+    @IsOptional()
+    @Transform(({ value }) => Number(value) || 30)
+    @IsNumber()
+    @Min(1)
+    days?: number;
 }
 
 
@@ -120,10 +156,6 @@ export class UpdateReviewStatus {
     @IsNotEmpty()
     @IsString()
     reviewId: string;
-
-    @IsNotEmpty()
-    @IsString()
-    providerId: string;
 
     @IsNotEmpty()
     @IsBoolean()

--- a/src/modules/users/services/implementations/admin-reviews.service.ts
+++ b/src/modules/users/services/implementations/admin-reviews.service.ts
@@ -62,4 +62,35 @@ export class AdminReviewService implements IAdminReviewService {
             throw new InternalServerErrorException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
     }
+
+    async lowestRatedProviders(limit: number = 5): Promise<IResponse> {
+        try {
+            const providers = await this._bookingRepository.getLowestRatedProviders(limit);
+
+            for (const provider of providers) {
+                provider.providerAvatar = this._uploadUtility.getSignedImageUrl(provider.providerAvatar);
+            }
+
+            return {
+                success: true,
+                message: 'Lowest rated providers fetched successfully',
+                data: providers
+            };
+        } catch (error) {
+            throw new InternalServerErrorException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    async ratingTrend(days: number = 30): Promise<IResponse> {
+        try {
+            const trend = await this._bookingRepository.getRatingTrend(days);
+            return {
+                success: true,
+                message: 'Rating trend fetched successfully',
+                data: trend
+            };
+        } catch (error) {
+            throw new InternalServerErrorException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/modules/users/services/interfaces/admin-reviews-service.interface.ts
+++ b/src/modules/users/services/interfaces/admin-reviews-service.interface.ts
@@ -7,4 +7,6 @@ export interface IAdminReviewService {
     getReviews(filter: IReviewFilters): Promise<IResponse>;
     updateReviewStatus(updateReviewStatus: UpdateReviewStatus): Promise<IResponse>;
     reviewStats(): Promise<IResponse>;
+    lowestRatedProviders(limit?: number): Promise<IResponse>;
+    ratingTrend(days?: number): Promise<IResponse>;
 }


### PR DESCRIPTION
- FilterWithPaginationDto extended with optional status and isReported fields ('true' → true, 'false' → false, 'all' → 'all', validated via @IsIn([true, false, 'all']))
- getAdminReviews (bookings.repository.ts) adds matching $match conditions on review.isActive / review.isReported when the filter is not 'all' — no pipeline changes
- IReviewFilters interface extended with status?: boolean | 'all' and isReported?: boolean | 'all'
- Zero new endpoints; both filters ride the existing GET /admin/reviews route