### PR TITLE
fix(availability): normalize date overrides to UTC midnight and harden validation

### DIFF
--- a/src/core/dto-mapper/implementation/availability.mapper.ts
+++ b/src/core/dto-mapper/implementation/availability.mapper.ts
@@ -7,6 +7,7 @@ import { DateOverrideDocument } from "@core/schema/date-overrides.schema";
 import { WeeklyAvailabilityDocument } from "@core/schema/weekly-availability.schema";
 import { Injectable } from "@nestjs/common";
 import { Types } from "mongoose";
+import { toUtcMidnight } from "@core/utilities/date.utility";
 
 @Injectable()
 export class AvailabilityMapper implements IAvailabilityMapper {
@@ -87,12 +88,9 @@ export class AvailabilityMapper implements IAvailabilityMapper {
     }
 
     toDateOverrideDocument(entity: Omit<IDateOverride, 'id'>): Partial<DateOverrideDocument> {
-        const date = new Date(entity.date);
-        date.setHours(0, 0, 0, 0);
-
         return {
             providerId: new Types.ObjectId(entity.providerId),
-            date,
+            date: toUtcMidnight(entity.date),
             reason: entity.reason ?? '',
             timeRanges: entity.timeRanges,
             isAvailable: entity.isAvailable,

--- a/src/core/repositories/implementations/date-overrides.repository.ts
+++ b/src/core/repositories/implementations/date-overrides.repository.ts
@@ -2,6 +2,7 @@ import { DATE_OVERRIDE_MODEL_NAME } from "@core/constants/model.constant";
 import { BaseRepository } from "@core/repositories/base/implementations/base.repository";
 import { IDateOverridesRepository } from "@core/repositories/interfaces/date-overrides.repo.interface";
 import { DateOverrideDocument } from "@core/schema/date-overrides.schema";
+import { toUtcMidnight } from "@core/utilities/date.utility";
 import { Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import { Model } from "mongoose";
@@ -27,8 +28,7 @@ export class DateOverridesRepository extends BaseRepository<DateOverrideDocument
     }
 
     async deleteOneByProviderIdAndDate(providerId: string, date: Date): Promise<boolean> {
-        const targetDate = new Date(date);
-        targetDate.setHours(0, 0, 0, 0);
+        const targetDate = toUtcMidnight(date);
 
         const result = await this._dateOverrideModel.deleteOne(
             {
@@ -36,28 +36,23 @@ export class DateOverridesRepository extends BaseRepository<DateOverrideDocument
                 date: targetDate,
             });
 
+            console.log(result)
+
         return result.deletedCount === 1;
     }
 
     async isValidOverrideDate(providerId: string, date: Date): Promise<boolean> {
-        const targetDate = new Date(date);
-        targetDate.setHours(0, 0, 0, 0);
-
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
+        const targetDate = toUtcMidnight(date);
+        const today = toUtcMidnight(new Date());
 
         if (targetDate <= today) {
             return false;
         }
 
-        const exists = await this._dateOverrideModel.exists({
-            providerId: this._toObjectId(providerId),
-            date: {
-                $gte: targetDate,
-                $lt: new Date(targetDate.getTime() + 24 * 60 * 60 * 1000)
-            }
-        });
+        const overrides = await this.fetchOverridesByProviderId(providerId);
 
-        return !!exists;
+        return overrides.some(override =>
+            toUtcMidnight(override.date).getTime() === targetDate.getTime()
+        );
     }
 }

--- a/src/core/utilities/date.utility.ts
+++ b/src/core/utilities/date.utility.ts
@@ -1,0 +1,8 @@
+export function toUtcMidnight(value: string | number | Date): Date {
+    const date = new Date(value);
+    return new Date(Date.UTC(
+        date.getUTCFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate(),
+    ));
+}

--- a/src/modules/availability/dto/availability.dto.ts
+++ b/src/modules/availability/dto/availability.dto.ts
@@ -2,7 +2,7 @@ import { Type } from 'class-transformer';
 import { ArrayMinSize, IsArray, IsBoolean, IsDateString, IsOptional, IsString, Matches, MaxLength, MinLength, ValidateIf, ValidateNested } from 'class-validator';
 
 export class DateDto {
-    @IsString()
+    @IsDateString()
     date: string;
 }
 

--- a/src/modules/availability/services/implementation/availability.service.ts
+++ b/src/modules/availability/services/implementation/availability.service.ts
@@ -12,6 +12,7 @@ import { ITimeUtility } from "@core/utilities/interface/time.utility.interface";
 import { CreateDateOverrideDto, UpdateWeeklyAvailabilityDto } from "@modules/availability/dto/availability.dto";
 import { IAvailabilityService } from "@modules/availability/services/interface/availability-service.interface";
 import { BadRequestException, Inject, Injectable, InternalServerErrorException } from "@nestjs/common";
+import { toUtcMidnight } from "@core/utilities/date.utility";
 
 @Injectable()
 export class AvailabilityService implements IAvailabilityService {
@@ -103,7 +104,20 @@ export class AvailabilityService implements IAvailabilityService {
     }
 
     async createDateOverride(providerId: string, dateOverrideDto: CreateDateOverrideDto): Promise<IResponse<IDateOverride>> {
-        const isValidOverrideDate = await this._dateOverrideRepository.isValidOverrideDate(providerId, new Date(dateOverrideDto.date));
+        const targetDate = toUtcMidnight(new Date(dateOverrideDto.date));
+        const today = toUtcMidnight(new Date());
+
+        if (Number.isNaN(targetDate.getTime())) throw new BadRequestException({
+            code: ErrorCodes.BAD_REQUEST,
+            message: 'Invalid date',
+        });
+
+        if (targetDate < today) throw new BadRequestException({
+            code: ErrorCodes.BAD_REQUEST,
+            message: 'Past dates cannot be scheduled',
+        });
+
+        const isValidOverrideDate = await this._dateOverrideRepository.isValidOverrideDate(providerId, targetDate);
         if (isValidOverrideDate) throw new BadRequestException({
             code: ErrorCodes.BAD_REQUEST,
             message: 'Date override already exists or Invalid date',
@@ -134,8 +148,12 @@ export class AvailabilityService implements IAvailabilityService {
     }
 
     async deleteDateOverride(providerId: string, date: string): Promise<IResponse> {
-        const dateSent = new Date(date);
-        dateSent.setHours(0, 0, 0, 0);
+        const dateSent = toUtcMidnight(date);
+
+        if (Number.isNaN(dateSent.getTime())) throw new BadRequestException({
+            code: ErrorCodes.BAD_REQUEST,
+            message: 'Invalid date',
+        });
 
         const isDeleted = await this._dateOverrideRepository.deleteOneByProviderIdAndDate(providerId, dateSent);
 

--- a/src/modules/providers/dtos/provider.dto.ts
+++ b/src/modules/providers/dtos/provider.dto.ts
@@ -1,5 +1,5 @@
 import { Transform, Type } from 'class-transformer';
-import { IsDefined, IsIn, isNotEmpty, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsDefined, IsIn, isNotEmpty, IsNotEmpty, IsNumber, IsOptional, IsString, Max, Min, ValidateNested } from 'class-validator';
 import { UploadsType } from '@core/enum/uploads.enum';
 import { FilterStatusType } from '@core/entities/interfaces/user.entity.interface';
 import { AvailabilityEnum } from '@core/enum/slot.enum';
@@ -173,6 +173,8 @@ export class UpdatePasswordDto {
 export class UpdateBufferTimeDto {
     @IsNotEmpty()
     @IsNumber()
+    @Min(0, { message: 'Buffer time must be a positive number' })
+    @Max(1440, { message: 'Buffer time cannot exceed 1440 minutes' })
     bufferTime: number;
 }
 


### PR DESCRIPTION
- Add toUtcMidnight utility; use it in availability mapper, date-overrides repo, and availability service
- Validate DateDto with @IsDateString; reject invalid and past dates on create/delete
- Rewrite isValidOverrideDate to compare UTC-normalized dates
- Constrain provider buffer time to 0-1440 minutes with Min/Max decorators