### PR TITLE
fix(dashboard & uploads): safe empty-state payload + long-lived avatar URLs

### DIFF
--- a/src/configs/cloudinary/cloudinary.service.ts
+++ b/src/configs/cloudinary/cloudinary.service.ts
@@ -73,7 +73,7 @@ export class CloudinaryService {
     return await this._cloudinary.uploader.destroy(publicId);
   }
 
-  generateSignedUrl(publicId: string, expiresIn = 300): string {
+  generateSignedUrl(publicId: string, expiresIn = 31536000): string {
     return this._cloudinary.url(publicId, {
       type: 'authenticated',
       sign_url: true,

--- a/src/core/entities/interfaces/booking.entity.interface.ts
+++ b/src/core/entities/interfaces/booking.entity.interface.ts
@@ -399,6 +399,23 @@ export interface IBookingsBreakdown {
     averageBookingValue: number;
 }
 
+export interface IUpcomingBooking {
+    bookingId: string;
+    amount: number;
+    status: BookingStatus;
+    slot: ISlot & { date: Date | string };
+    customer: {
+        id: string;
+        username: string;
+        fullname: string;
+        avatar: string;
+    };
+    service: {
+        name: string;
+        category: string;
+    };
+}
+
 export interface IReviewDetailsRaw {
     bookingId: string;
     desc: string;

--- a/src/core/entities/interfaces/user.entity.interface.ts
+++ b/src/core/entities/interfaces/user.entity.interface.ts
@@ -5,7 +5,8 @@ import { SlotType } from '../../../modules/bookings/dtos/booking.dto';
 import { IBaseUserEntity } from '../base/interfaces/base-user.entity.interface';
 import { IAdmin } from './admin.entity.interface';
 import { IDisputeAnalytics } from './report.entity.interface';
-import { IBookingsBreakdown, INewOrReturningClientData, IPagination, IRatingDistribution, IRecentReviews, IRevenueBreakdown, IRevenueCompositionData, IRevenueMonthlyGrowthRateData, IRevenueTrendData, IReview, ISlot, ITopServicesByRevenue } from './booking.entity.interface';
+import { IBookingsBreakdown, INewOrReturningClientData, IPagination, IRatingDistribution, IRecentReviews, IRevenueBreakdown, IRevenueCompositionData, IRevenueMonthlyGrowthRateData, IRevenueTrendData, IReview, ISlot, ITopServicesByRevenue, IUpcomingBooking } from './booking.entity.interface';
+import { IBookingOverview } from './admin-user-details.entity.interface';
 
 export type UserType = 'customer' | 'provider' | 'admin';
 export type ClientUserType = Exclude<UserType, 'admin'>;
@@ -323,4 +324,10 @@ export interface IProviderDashboardOverview {
   workingHours: Availability | null;
   nextAvailableSlot: ISlot & { date: Date | string } | null;
   activeServiceCount: number;
+  nextBooking: IUpcomingBooking | null;
+  upcomingBookingCount: number;
+  recentBookings: IBookingOverview[];
+  wallet: {
+    balance: number;
+  } | null;
 }

--- a/src/core/repositories/implementations/bookings.repository.ts
+++ b/src/core/repositories/implementations/bookings.repository.ts
@@ -2,7 +2,7 @@ import { FilterQuery, Model, PipelineStage, Types } from 'mongoose';
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { BOOKINGS_MODEL_NAME } from '@core/constants/model.constant';
-import { IBookingStats, IRatingDistribution, IRevenueMonthlyGrowthRateData, IRevenueTrendRawData, RevenueChartView, IRevenueCompositionData, ITopServicesByRevenue, INewOrReturningClientData, IAreaSummary, IServiceDemandData, ILocationRevenue, ITopAreaRevenue, IUnderperformingArea, IPeakServiceTime, IRevenueBreakdown, IBookingsBreakdown, IReviewDetailsRaw, IReviewFilter, IAdminBookingFilter, IAdminBookingList, ISlot, IBookedSlot, IProviderBookingLists } from '@core/entities/interfaces/booking.entity.interface';
+import { IBookingStats, IRatingDistribution, IRevenueMonthlyGrowthRateData, IRevenueTrendRawData, RevenueChartView, IRevenueCompositionData, ITopServicesByRevenue, INewOrReturningClientData, IAreaSummary, IServiceDemandData, ILocationRevenue, ITopAreaRevenue, IUnderperformingArea, IPeakServiceTime, IRevenueBreakdown, IBookingsBreakdown, IReviewDetailsRaw, IReviewFilter, IAdminBookingFilter, IAdminBookingList, ISlot, IBookedSlot, IProviderBookingLists, IUpcomingBooking } from '@core/entities/interfaces/booking.entity.interface';
 import { IBookingPerformanceData, IComparisonChartData, IComparisonOverviewData, IOnTimeArrivalChartData, IProviderRevenueOverview, IResponseTimeChartData, IReviewFilters, ITopProviders, ITotalReviewAndAvgRating, PaginatedReviewResponse } from '@core/entities/interfaces/user.entity.interface';
 import { BookingDocument, SlotDocument } from '@core/schema/bookings.schema';
 import { BaseRepository } from '@core/repositories/base/implementations/base.repository';
@@ -2698,7 +2698,12 @@ totalRevenue: { $sum: { $divide: ["$totalAmount", 100] } }
             }
         ]);
 
-        return result[0]
+        return result?.[0] ?? {
+            totalBookings: 0,
+            upcomingBookings: 0,
+            cancelledBookings: 0,
+            averageBookingValue: 0,
+        }
     }
 
     async getBookingsCompletionRate(providerId: string): Promise<number> {
@@ -2842,6 +2847,98 @@ totalRevenue: { $sum: { $divide: ["$totalAmount", 100] } }
         ]);
 
         return result?.[0]?.slot;
+    }
+
+    async getUpcomingBookings(providerId: string, limit: number = 5): Promise<IUpcomingBooking[]> {
+        const providerObjId = this._toObjectId(providerId);
+
+        return this._bookingModel.aggregate<IUpcomingBooking>([
+            {
+                $match: {
+                    providerId: providerObjId,
+                    bookingStatus: {
+                        $in: [
+                            BookingStatus.PENDING,
+                            BookingStatus.CONFIRMED,
+                            BookingStatus.IN_PROGRESS,
+                        ]
+                    },
+                }
+            },
+            { $sort: { 'slot.date': 1, 'slot.from': 1 } },
+            { $limit: limit },
+            {
+                $lookup: {
+                    from: 'customers',
+                    localField: 'customerId',
+                    foreignField: '_id',
+                    as: 'customerDoc',
+                },
+            },
+            { $unwind: { path: '$customerDoc', preserveNullAndEmptyArrays: true } },
+            {
+                $lookup: {
+                    from: 'providerservices',
+                    localField: 'services',
+                    foreignField: '_id',
+                    as: 'serviceDocs',
+                },
+            },
+            {
+                $addFields: {
+                    firstService: { $arrayElemAt: ['$serviceDocs', 0] },
+                },
+            },
+            {
+                $lookup: {
+                    from: 'professions',
+                    let: { pid: '$firstService.professionId' },
+                    pipeline: [
+                        { $match: { $expr: { $eq: ['$_id', '$$pid'] } } },
+                        { $limit: 1 },
+                        { $project: { _id: 0, name: 1 } },
+                    ],
+                    as: 'serviceProfession',
+                },
+            },
+            { $unwind: { path: '$serviceProfession', preserveNullAndEmptyArrays: true } },
+            {
+                $lookup: {
+                    from: 'servicecategories',
+                    let: { cid: '$firstService.categoryId' },
+                    pipeline: [
+                        { $match: { $expr: { $eq: ['$_id', '$$cid'] } } },
+                        { $limit: 1 },
+                        { $project: { _id: 0, name: 1 } },
+                    ],
+                    as: 'serviceCategory',
+                },
+            },
+            { $unwind: { path: '$serviceCategory', preserveNullAndEmptyArrays: true } },
+            {
+                $project: {
+                    _id: 0,
+                    bookingId: { $toString: '$_id' },
+                    amount: { $divide: [{ $ifNull: ['$totalAmount', 0] }, 100] },
+                    status: '$bookingStatus',
+                    slot: {
+                        from: '$slot.from',
+                        to: '$slot.to',
+                        date: '$slot.date',
+                    },
+                    customer: {
+                        id: { $toString: '$customerDoc._id' },
+                        username: { $ifNull: ['$customerDoc.username', ''] },
+                        fullname: { $ifNull: ['$customerDoc.fullname', '$customerDoc.username'] },
+                        avatar: { $ifNull: ['$customerDoc.avatar', ''] },
+                    },
+                    service: {
+                        name: { $ifNull: ['$serviceProfession.name', ''] },
+                        category: { $ifNull: ['$serviceCategory.name', ''] },
+                    },
+                },
+            },
+        ]);
     }
 
     async getAdminReviews(filter: IReviewFilters): Promise<PaginatedReviewResponse> {

--- a/src/core/repositories/interfaces/bookings-repo.interface.ts
+++ b/src/core/repositories/interfaces/bookings-repo.interface.ts
@@ -1,5 +1,5 @@
 import { FilterQuery, Types } from 'mongoose';
-import { IBookingStats, IRatingDistribution, IRevenueMonthlyGrowthRateData, IRevenueTrendRawData, RevenueChartView, IRevenueCompositionData, ITopServicesByRevenue, INewOrReturningClientData, IAreaSummary, IServiceDemandData, ILocationRevenue, ITopAreaRevenue, IUnderperformingArea, IPeakServiceTime, IRevenueBreakdown, IBookingsBreakdown, IReviewDetailsRaw, IReviewFilter, IAdminBookingFilter, IAdminBookingList, ISlot, IBookedSlot, IProviderBookingLists } from '@core/entities/interfaces/booking.entity.interface';
+import { IBookingStats, IRatingDistribution, IRevenueMonthlyGrowthRateData, IRevenueTrendRawData, RevenueChartView, IRevenueCompositionData, ITopServicesByRevenue, INewOrReturningClientData, IAreaSummary, IServiceDemandData, ILocationRevenue, ITopAreaRevenue, IUnderperformingArea, IPeakServiceTime, IRevenueBreakdown, IBookingsBreakdown, IReviewDetailsRaw, IReviewFilter, IAdminBookingFilter, IAdminBookingList, ISlot, IBookedSlot, IProviderBookingLists, IUpcomingBooking } from '@core/entities/interfaces/booking.entity.interface';
 import { IBookingPerformanceData, IComparisonChartData, IComparisonOverviewData, IOnTimeArrivalChartData, IProviderRevenueOverview, IResponseTimeChartData, IReviewFilters, ITopProviders, ITotalReviewAndAvgRating, PaginatedReviewResponse } from '@core/entities/interfaces/user.entity.interface';
 import { IBaseRepository } from '@core/repositories/base/interfaces/base-repo.interface';
 import { BookingDocument, SlotDocument } from '@core/schema/bookings.schema';
@@ -40,6 +40,7 @@ export interface IBookingRepository extends IBaseRepository<BookingDocument> {
     getProviderStatistics(id: string): Promise<IProviderStatistics>;
     getRecentBookingsByCustomer(customerId: string, limit?: number): Promise<IBookingOverview[]>;
     getRecentBookingsByProvider(providerId: string, limit?: number): Promise<IBookingOverview[]>;
+    getUpcomingBookings(providerId: string, limit?: number): Promise<IUpcomingBooking[]>;
     getRecentReviewsByCustomer(customerId: string, limit?: number): Promise<IReviewOverview[]>;
     getRecentReviewsByProvider(providerId: string, limit?: number): Promise<IReviewOverview[]>;
     getServiceBookingCounts(providerId: string): Promise<{ serviceId: string; count: number }[]>;

--- a/src/core/utilities/implementations/upload.utility.ts
+++ b/src/core/utilities/implementations/upload.utility.ts
@@ -66,7 +66,7 @@ export class UploadsUtility implements IUploadsUtility {
     }
   }
 
-  getSignedImageUrl(publicId: string, expiresIn: number = 300): string {
+  getSignedImageUrl(publicId: string, expiresIn: number = 31536000): string {
     if (!publicId || !publicId.trim()) return '';
 
     const googleDomains = [

--- a/src/modules/landing/services/implementations/landing.service.ts
+++ b/src/modules/landing/services/implementations/landing.service.ts
@@ -27,7 +27,7 @@ export class LandingService implements ILandingService {
         const providers = featuredProviders.map(provider => ({
             ...provider,
             avatar: provider.avatar
-                ? this._uploadsUtility.getSignedImageUrl(provider.avatar, 5)
+                ? this._uploadsUtility.getSignedImageUrl(provider.avatar)
                 : '',
         }));
 

--- a/src/modules/providers/providers/repository.provider.ts
+++ b/src/modules/providers/providers/repository.provider.ts
@@ -1,12 +1,12 @@
 import {
   BOOKINGS_MODEL_NAME, CART_MODEL_NAME, CUSTOMER_MODEL_NAME, DATE_OVERRIDE_MODEL_NAME, PROVIDER_MODEL_NAME, PROVIDER_SERVICE_MODEL_NAME, REPORT_MODEL_NAME, SERVICE_OFFERED_MODEL_NAME,
-  WEEKLY_AVAILABILITY_MODEL_NAME, RESERVATION_MODEL_NAME, SERVICE_CATEGORY_MODEL_NAME
+  WEEKLY_AVAILABILITY_MODEL_NAME, RESERVATION_MODEL_NAME, SERVICE_CATEGORY_MODEL_NAME, WALLET_MODEL_NAME
 } from '@core/constants/model.constant';
 
 import {
   BOOKING_REPOSITORY_NAME, CART_REPOSITORY_NAME, DATE_OVERRIDES_REPOSITORY_INTERFACE_NAME, PROVIDER_REPOSITORY_INTERFACE_NAME, PROVIDER_SERVICE_REPOSITORY_NAME,
   REPORT_REPOSITORY_NAME, SERVICE_OFFERED_REPOSITORY_NAME, WEEKLY_AVAILABILITY_REPOSITORY_INTERFACE_NAME, RESERVATION_REPOSITORY_NAME,
-  CUSTOMER_REPOSITORY_INTERFACE_NAME, SERVICE_CATEGORY_REPOSITORY_NAME
+  CUSTOMER_REPOSITORY_INTERFACE_NAME, SERVICE_CATEGORY_REPOSITORY_NAME, WALLET_REPOSITORY_NAME
 } from '@core/constants/repository.constant';
 
 import { Model } from 'mongoose';
@@ -34,6 +34,9 @@ import { ReservationRepository } from '@core/repositories/implementations/reserv
 import { CartDocument } from '@core/schema/cart.schema';
 import { ServiceCategoryDocument } from '@core/schema/service-category';
 import { ServiceCategoryRepository } from '@core/repositories/implementations/service-category.repository';
+import { WalletRepository } from '@core/repositories/implementations/wallet.repository';
+import { WalletDocument } from '@core/schema/wallet.schema';
+import { LoggerFactory } from '@core/logger/implementation/logger.factory';
 
 export const repositoryProviders: Provider[] = [
   {
@@ -101,5 +104,11 @@ export const repositoryProviders: Provider[] = [
     useFactory: (serviceCategoryModel: Model<ServiceCategoryDocument>) =>
       new ServiceCategoryRepository(serviceCategoryModel),
     inject: [getModelToken(SERVICE_CATEGORY_MODEL_NAME)]
+  },
+  {
+    provide: WALLET_REPOSITORY_NAME,
+    useFactory: (walletModel: Model<WalletDocument>) =>
+      new WalletRepository(new LoggerFactory(), walletModel),
+    inject: [getModelToken(WALLET_MODEL_NAME)]
   }
 ];

--- a/src/modules/providers/services/implementations/dashboard.service.ts
+++ b/src/modules/providers/services/implementations/dashboard.service.ts
@@ -1,10 +1,13 @@
-import { BOOKING_REPOSITORY_NAME, PROVIDER_REPOSITORY_INTERFACE_NAME, PROVIDER_SERVICE_REPOSITORY_NAME } from "@core/constants/repository.constant";
+import { BOOKING_REPOSITORY_NAME, PROVIDER_REPOSITORY_INTERFACE_NAME, PROVIDER_SERVICE_REPOSITORY_NAME, WALLET_REPOSITORY_NAME } from "@core/constants/repository.constant";
 import { IProviderDashboardOverview } from "@core/entities/interfaces/user.entity.interface";
 import { IResponse } from "@core/misc/response.util";
 import { IBookingRepository } from "@core/repositories/interfaces/bookings-repo.interface";
 import { IProviderRepository } from "@core/repositories/interfaces/provider-repo.interface";
 import { IProviderServiceRepository } from "@core/repositories/interfaces/provider-service-repo.interface";
+import { IWalletRepository } from "@core/repositories/interfaces/wallet-repo.interface";
 import { IProviderDashboardService } from "@modules/providers/services/interfaces/dashboard-service.interface";
+import { UPLOAD_UTILITY_NAME } from "@core/constants/utility.constant";
+import { IUploadsUtility } from "@core/utilities/interface/upload.utility.interface";
 import { Inject, Injectable } from "@nestjs/common";
 
 @Injectable()
@@ -16,18 +19,40 @@ export class providerDashboardService implements IProviderDashboardService {
         private readonly _providerRepository: IProviderRepository,
         @Inject(PROVIDER_SERVICE_REPOSITORY_NAME)
         private readonly _providerServiceRepository: IProviderServiceRepository,
+        @Inject(WALLET_REPOSITORY_NAME)
+        private readonly _walletRepository: IWalletRepository,
+        @Inject(UPLOAD_UTILITY_NAME)
+        private readonly _uploadsUtility: IUploadsUtility,
     ) { }
 
     async getDashboardOverviewBreakdown(providerId: string): Promise<IResponse<IProviderDashboardOverview>> {
-        const [revenue, bookings, avgRating, completionRate, workingHours, activeServiceCount, nextAvailableSlot] = await Promise.all([
+        const [revenue, bookings, avgRating, completionRate, workingHours, activeServiceCount, nextAvailableSlot, upcoming, recent, wallet] = await Promise.all([
             this._bookingRepository.getRevenueBreakdown(providerId),
             this._bookingRepository.getBookingsBreakdown(providerId),
             this._bookingRepository.getAvgRating(providerId),
             this._bookingRepository.getBookingsCompletionRate(providerId),
             this._providerRepository.getWorkingHours(providerId),
             this._providerServiceRepository.count({ providerId, isActive: true }),
-            this._bookingRepository.getNextAvailableSlot(providerId)
+            this._bookingRepository.getNextAvailableSlot(providerId),
+            this._bookingRepository.getUpcomingBookings(providerId, 5),
+            this._bookingRepository.getRecentBookingsByProvider(providerId, 5),
+            this._walletRepository.findWallet(providerId)
         ]);
+
+        const recentBookings = recent.map(r => ({
+            ...r,
+            customer: r.customer
+                ? { ...r.customer, avatar: r.customer.avatar ? this._uploadsUtility.getSignedImageUrl(r.customer.avatar) : '' }
+                : r.customer,
+            provider: r.provider
+                ? { ...r.provider, avatar: r.provider.avatar ? this._uploadsUtility.getSignedImageUrl(r.provider.avatar) : '' }
+                : r.provider,
+        }));
+
+        const nextBooking = upcoming[0] ?? null;
+        if (nextBooking?.customer?.avatar) {
+            nextBooking.customer.avatar = this._uploadsUtility.getSignedImageUrl(nextBooking.customer.avatar);
+        }
 
         const response: IProviderDashboardOverview = {
             revenue,
@@ -36,7 +61,11 @@ export class providerDashboardService implements IProviderDashboardService {
             nextAvailableSlot,
             workingHours,
             completionRate,
-            activeServiceCount
+            activeServiceCount,
+            nextBooking,
+            upcomingBookingCount: upcoming.length,
+            recentBookings,
+            wallet: wallet ? { balance: wallet.balance } : null,
         };
 
         return {


### PR DESCRIPTION
- getBookingsBreakdown no longer returns undefined for providers without bookings — it now emits a zeroed { totalBookings, upcomingBookings, cancelledBookings, averageBookingValue }, so bookings is always present in the dashboard overview payload.
- Raise default signed-image URL expiry from 300s to 31536000s (1 year) in CloudinaryService.generateSignedUrl and UploadsUtility.getSignedImageUrl so cached avatars stop expiring mid-session.
- Stop signing featuredProviders avatars with a 5-second expiry on the landing page — now uses the long-lived default.